### PR TITLE
DSCS-1085 - add edgeOrder to Work model

### DIFF
--- a/src/main/java/au/gov/nla/dlir/models/Work.java
+++ b/src/main/java/au/gov/nla/dlir/models/Work.java
@@ -64,6 +64,7 @@ public class Work  implements Comparable<Object>{
     private Children children;
     private List<Copies> copies;
     private List<String> constraints;
+    private int edgeOrder;
     
     /**
      * Returns the BibData of this Object or
@@ -503,5 +504,14 @@ public class Work  implements Comparable<Object>{
 
     public void setConstraints(List<String> constraints) {
         this.constraints = constraints;
+    }
+
+    public int getEdgeOrder() {
+        return edgeOrder;
+    }
+
+    public Work setEdgeOrder(int edgeOrder) {
+        this.edgeOrder = edgeOrder;
+        return this;
     }
 }


### PR DESCRIPTION
@AaronCMuller @terenceingram This change is required in order to display the right "set" of results in the browse panel widget and obtain the correct starting offset for the children service.