### PR TITLE
DSCS-2149 Tarkine: change to map index label rules in viewer.

### DIFF
--- a/src/main/java/au/gov/nla/dlir/models/map/MapIndex.java
+++ b/src/main/java/au/gov/nla/dlir/models/map/MapIndex.java
@@ -15,6 +15,7 @@ public class MapIndex {
     private boolean hasFlightDiagramCopy;
     private String interactiveHtml;
     private List<Neighbour> navigation;
+    private String collection;
 
     public String getPid() {
         return pid;
@@ -75,5 +76,13 @@ public class MapIndex {
 
     public void setNavigation(List<Neighbour> navigation) {
         this.navigation = navigation;
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    public void setCollection(String collection) {
+        this.collection = collection;
     }
 }


### PR DESCRIPTION
Add collection to MapIndex so that the viewer can decide whether to call
the index "Map Index" or "Index", as per DSCS-2149.

@shuangzhou @ninhnguyen @yetti @josephcurtis @snezanam @weijunnla