### PR TITLE
AJCP-56 adds topLevelCollection property to the Work class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>au.gov.nla</groupId>
   <artifactId>dl-models</artifactId>
   <packaging>jar</packaging>
-  <version>1.6.9-SNAPSHOT</version>
+  <version>1.6.10-SNAPSHOT</version>
   <name>dl-models</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/src/main/java/au/gov/nla/dlir/models/Work.java
+++ b/src/main/java/au/gov/nla/dlir/models/Work.java
@@ -80,6 +80,7 @@ public class Work  implements Comparable<Object>{
     private Date expiryDate;
     private String depositType;
     private boolean isOriginalCopyAvaliable = false;
+    private String topLevelCollection;
     /**
      * Returns the BibData of this Object or
      * if null returns the BibData of the Parent
@@ -647,4 +648,11 @@ public class Work  implements Comparable<Object>{
         this.isOriginalCopyAvaliable = isOriginalCopyAvaliable;
     }
 
+    public String getTopLevelCollection() {
+        return topLevelCollection;
+    }
+
+    public void setTopLevelCollection(String topLevelCollection) {
+        this.topLevelCollection = topLevelCollection;
+    }
 }


### PR DESCRIPTION
This will be used by Tarkine and dl-repo to include the top level parent work for any work. See the corresponding pull request https://github.com/nla/dl-repository-service/pull/210 for dl-repo, which optionally includes this property when retrieving work metadata. Tarkine will use this field to include the top level collection in Google Analytics calls as part of the AJCP changes to tarkine (this is part of the MC-AJCP-47 branch of Tarkine - check the header.ftl file for this particular change -https://github.com/nla/tarkine/commit/b8261bd8d6f4db195999de2b3704ee2998700373).
 
@adityaburra @ninhnguyen @snezanam @sjacob  