### PR TITLE
feat(corrections): adds mapping for articleType column to CorrectionMetadata class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.class
+*.DS_Store
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/src/main/java/au/gov/nla/dlir/models/Content.java
+++ b/src/main/java/au/gov/nla/dlir/models/Content.java
@@ -92,6 +92,7 @@ public class Content {
      */
     @JsonAnySetter
     public void handleUnknown(String key, Object value) {
+      // Ignore unknown values
     }
 
     public String getId() {
@@ -134,7 +135,7 @@ public class Content {
         }
         
         if (publishDates != null && publishDates.size() > 0 && 
-            citedYears != null & citedYears.size() > 0) {
+            citedYears != null && citedYears.size() > 0) {
             return citedYears.get(0);
         }
 		return publishDate;

--- a/src/main/java/au/gov/nla/dlir/models/correction/CorrectionMetadata.java
+++ b/src/main/java/au/gov/nla/dlir/models/correction/CorrectionMetadata.java
@@ -1,14 +1,12 @@
 package au.gov.nla.dlir.models.correction;
 
 import au.gov.nla.dlir.util.UsernameUtils;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -28,6 +26,7 @@ public class CorrectionMetadata {
   private Long beforeId;
   private Date created;
   private Date updated;
+  private String articleType;
 
   public String getCleanOldLines() {
     return Optional.ofNullable(oldLines).map(CorrectionMetadata::cleanText).orElse(null);

--- a/src/main/java/au/gov/nla/dlir/util/NaturalSort.java
+++ b/src/main/java/au/gov/nla/dlir/util/NaturalSort.java
@@ -34,21 +34,13 @@ public final class NaturalSort {
      * <p>A string comparator that does case sensitive comparisons and handles embedded numbers correctly.</p>
      * <p><b>Do not use</b> if your app might ever run on any locale that uses more than 7-bit ascii characters.</p>
      */
-    private static final Comparator<String> NATURAL_COMPARATOR_ASCII = new Comparator<String>() {
-        public int compare(String o1, String o2) {
-            return compareNaturalAscii(o1, o2);
-        }
-    };
+    private static final Comparator<String> NATURAL_COMPARATOR_ASCII = NaturalSort::compareNaturalAscii;
 
     /**
      * <p>A string comparator that does case insensitive comparisons and handles embedded numbers correctly.</p>
      * <p><b>Do not use</b> if your app might ever run on any locale that uses more than 7-bit ascii characters.</p>
      */
-    private static final Comparator<String> IGNORE_CASE_NATURAL_COMPARATOR_ASCII = new Comparator<String>() {
-        public int compare(String o1, String o2) {
-            return compareNaturalIgnoreCaseAscii(o1, o2);
-        }
-    };
+    private static final Comparator<String> IGNORE_CASE_NATURAL_COMPARATOR_ASCII = NaturalSort::compareNaturalIgnoreCaseAscii;
 
     /**
      * This is a utility class (static methods only), don't instantiate.
@@ -86,11 +78,8 @@ public final class NaturalSort {
             // unrelated code that tries to use the comparator
             throw new NullPointerException("collator must not be null");
         }
-        return new Comparator<String>() {
-            public int compare(String o1, String o2) {
-                return compareNatural(collator, o1, o2);
-            }
-        };
+
+        return (String o1, String o2) -> compareNatural(collator, o1, o2);
     }
 
     /**

--- a/src/test/java/au/gov/nla/dlir/models/correction/CorrectionMetadataTest.java
+++ b/src/test/java/au/gov/nla/dlir/models/correction/CorrectionMetadataTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 public class CorrectionMetadataTest {
 
-  private CorrectionMetadata correctionMetadata = new CorrectionMetadata();
+  private final CorrectionMetadata correctionMetadata = new CorrectionMetadata();
 
   @Test
   public void getCleanNullOldLines() {


### PR DESCRIPTION
This is required in order to distinguish DLC text corrections from Newspapers/Gazettes.

re MDCU-784
