### PR TITLE
feat(corrections): adds additional fields for corrections

### DIFF
--- a/src/main/java/au/gov/nla/dlir/models/Parent.java
+++ b/src/main/java/au/gov/nla/dlir/models/Parent.java
@@ -1,10 +1,14 @@
 package au.gov.nla.dlir.models;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.util.Date;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
 public class Parent {
+
+    public static final String DATE_PATTERN = "EEE, d MMM yyyy";
 
     private String id;
     private String collection;
@@ -23,4 +27,7 @@ public class Parent {
     private BibData bibData;
     private Boolean interactiveIndexAvailable = false;
     private boolean ocrMetsCopyAvaliable;
+    private String creator;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_PATTERN, locale = "en_AU")
+    private Date issueDate;
 }

--- a/src/main/java/au/gov/nla/dlir/models/Work.java
+++ b/src/main/java/au/gov/nla/dlir/models/Work.java
@@ -26,7 +26,7 @@ public class Work implements Comparable<Object> {
     private String subType;
     private String subUnitType;
     private String subUnitNo = "";
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_PATTERN)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_PATTERN, locale = "en_AU")
     private Date issueDate;
     private String holdingNumber;
     private String pid;


### PR DESCRIPTION
Needed to add a couple new fields to expose data from dl-repo-service that needs to be displayed in the user's corrections.

I was getting Date deserialisation issues with Jackson in the `Parent` class when the locale was not specified in the `@JsonFormat` annotation. This is why I updated the `Work` class to also use a locale.