### PR TITLE
fix(corrections): fixes NPE when correction metadata has a null user

### DIFF
--- a/src/main/java/au/gov/nla/dlir/models/correction/CorrectionMetadata.java
+++ b/src/main/java/au/gov/nla/dlir/models/correction/CorrectionMetadata.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 @Getter
 @Setter
@@ -43,6 +44,6 @@ public class CorrectionMetadata {
   }
 
   public String getUserDisplay() {
-    return UsernameUtils.getDisplayUsername(user);
+    return StringUtils.isBlank(user) ? "" : UsernameUtils.getDisplayUsername(user);
   }
 }

--- a/src/test/java/au/gov/nla/dlir/models/correction/CorrectionMetadataTest.java
+++ b/src/test/java/au/gov/nla/dlir/models/correction/CorrectionMetadataTest.java
@@ -18,4 +18,12 @@ public class CorrectionMetadataTest {
     Assert.assertEquals(
         "TTTTTTT \nHONORARY EXECUTIVE COMMITTEE: \n", correctionMetadata.getCleanOldLines());
   }
+
+  @Test
+  public void testNullUserDisplayName() {
+    String displayName = correctionMetadata.getUserDisplay();
+
+    Assert.assertNotNull(displayName);
+    Assert.assertEquals(0, displayName.length());
+  }
 }


### PR DESCRIPTION
Returns an empty string instead of a null. I'm assuming it just gets displayed in the UI, but in case it gets processed further along somewhere else, it won't blow up as another NPE.