### PR TITLE
TVIT-38 adds partner metadata fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>au.gov.nla</groupId>
   <artifactId>dl-models</artifactId>
   <packaging>jar</packaging>
-  <version>1.6.17-RELEASE</version>
+  <version>1.6.18-SNAPSHOT</version>
   <name>dl-models</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/src/main/java/au/gov/nla/dlir/models/Work.java
+++ b/src/main/java/au/gov/nla/dlir/models/Work.java
@@ -94,6 +94,8 @@ public class Work implements Comparable<Object> {
     private String publisherName;
     private Boolean allowSearchEngineIndexing = false;
     private boolean atomisedInTrove;
+    private String partnerHoldingNumber;
+    private String partnerHoldingNuc;
 
     /**
      * Returns the BibData of this Object or


### PR DESCRIPTION
Adds partner metadata fields so they can be mapped and displayed in Tarkine.