### PR TITLE
Bump up commons-collection from 3.2.1 to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
To address https://github.com/nla/dl-models/security/dependabot/65